### PR TITLE
Fix keyerror for record with no files

### DIFF
--- a/check_b2share.py
+++ b/check_b2share.py
@@ -150,10 +150,7 @@ if __name__ == '__main__':
             rec_with_files_url = None
             for hit in search_results['hits']['hits']:
                 # Check if there are files in the record
-                if len(hit['files']) > 0:
-                    # NTS: Could throw KeyError if there is something
-                    # seriously wrong or B2SHARE REST API responses have
-                    # changed.
+                if len(hit.get('files', "")) > 0:
                     rec_with_files_url = hit['links']['self']
                     break
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,28 @@
+#
+# This file is part of B2SHARE Nagios monitoring plugin.
+#
+# Copyright (C) 2018 Harri Hirvonsalo
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+attrs==19.1.0           # from jsonschema
+certifi==2019.6.16      # from requests
+chardet==3.0.4          # from requests
+decorator==4.4.0        # from validators
+idna==2.8               # from requests
+jsonschema==3.0.2
+pyrsistent==0.15.4      # from jsonschema
+requests==2.22.0
+six==1.12.0             # from validators, jsonschema
+urllib3==1.25.3         # from requests 
+validators==0.14.0


### PR DESCRIPTION
'check_b2share.py' searches for records that contain files to check if file downloading works:
https://github.com/EUDAT-B2SHARE/b2share-nagios-plugin/blob/ec7b3b61ec6004272c637e6c12dbcd281e5a397c/check_b2share.py#L152

An incorrect, direct reference to 'files' key would raise a KeyError when a record which didn't contain any files was found.
This PR should prevent that KeyError from happening.

PR also includes requirements.txt for easier set up of the script.
